### PR TITLE
Introduce OpenIDConnect permissions for aws secrets for eks

### DIFF
--- a/customer_create_role.tf
+++ b/customer_create_role.tf
@@ -309,6 +309,23 @@ resource "aws_iam_policy" "deductive_policy" {
             "aws:ResourceTag/creator" : "deductive-ai"
           }
         }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:ListOpenIDConnectProviders"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:CreateOpenIDConnectProvider",
+          "iam:GetOpenIDConnectProvider",
+          "iam:DeleteOpenIDConnectProvider",
+          "iam:TagOpenIDConnectProvider",
+        ],
+        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.eks.*.amazonaws.com/id/*"
       }
     ]
   })
@@ -419,6 +436,7 @@ resource "aws_iam_role_policy_attachment" "secret_writer_reader_policy_attachmen
   role       = aws_iam_role.deductive_role.name
   policy_arn = aws_iam_policy.secret_writer_reader_policy.arn
 }
+
 
 output "deductive_role_arn" {
   description = "The ARN of the Deductive role"


### PR DESCRIPTION
This introduces the permission for OpenIDConnect creation for EKS as per aws official guide[https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html]

Test plan:
- On aws testcustomer
- Apply the change
- List the permission
```
aws iam list-open-id-connect-providers --profile customer-temp| grep $oidc_id | cut -d "/" -f4
<VALUE...>
```
- Asoociate
```
❯ eksctl utils associate-iam-oidc-provider --cluster $cluster_name --approve --profile customer-temp --region us-east-2
2024-12-11 15:41:37 [ℹ]  will create IAM Open ID Connect provider for cluster ... in "us-east-2"
2024-12-11 15:41:38 [✔]  created IAM Open ID Connect provider for cluster ... in "us-east-2"
```