### PR TITLE
More generic trusted cross account role on trust relationship

### DIFF
--- a/opensearch-cross-account-role.tf
+++ b/opensearch-cross-account-role.tf
@@ -25,6 +25,7 @@ variable "trusted_account_id" {
 variable "trusted_cross_account_role_name" {
   description = "Name of the role in the trusted account that needs access"
   type        = string
+  default     = "*DeductiveAIEC2Role*"
 }
 #################################################
 # Data Sources


### PR DESCRIPTION
This patch mainly aims on a more generic cross account role instead of static EC2 instance role. Making the ec2 role updates easier. 