### PR TITLE
Fix aws secret manager permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ This configuration creates:
 
 ```bash
 terraform init
-terraform plan -var="region=<aws_region>" -var="aws_profile=<aws_profile>"
-terraform apply -var="region=<aws_region>" -var="aws_profile=<aws_profile>"
+terraform plan -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>"
+terraform apply -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>"
 ```
-
-
-
-

--- a/create_role/main.tf
+++ b/create_role/main.tf
@@ -72,13 +72,3 @@ output "ec2_role_arn" {
   description = "The ARN of the EC2 instance role"
   value       = module.deductive_role.ec2_role_arn
 }
-
-output "secrets_reader_role_arn" {
-  description = "The ARN of the secrets reader role"
-  value       = module.deductive_role.secrets_reader_role_arn
-}
-
-output "secrets_writer_reader_role_arn" {
-  description = "The ARN of the secrets writer reader role"
-  value       = module.deductive_role.secrets_writer_reader_role_arn
-}

--- a/create_role/main.tf
+++ b/create_role/main.tf
@@ -30,7 +30,6 @@ variable "aws_profile" {
 variable "deductive_aws_account_id" {
   description = "Deductive AI's AWS account ID for cross-account permissions"
   type        = string
-  default     = "590183993904"
   sensitive   = true
 }
 

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -121,6 +121,7 @@ data "aws_iam_policy_document" "deductive_policy" {
     effect = "Allow"
     actions = [
       "ec2:RebootInstances",
+      "ec2:RunInstances",
     ]
     resources = [
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:*/*",

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -402,10 +402,8 @@ data "aws_iam_policy_document" "deductive_policy" {
       "iam:DeleteRolePolicy"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_prefix}SecretsReaderRole",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_prefix}SecretsWriterReaderRole",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/DeductiveAISecretsReaderRole",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/DeductiveAISecretsWriterReaderRole",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_prefix}*SecretsReaderRole",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.resource_prefix}*SecretsWriterReaderRole",
     ]
   }
 }

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -22,7 +22,7 @@
 #
 # 3. EC2Role - Role for EC2 instances that run as worker nodes in the EKS cluster
 #    - Permissions: AmazonEKSWorkerNodePolicy, AmazonEKS_CNI_Policy,
-#      AmazonEC2ContainerRegistryReadOnly, AmazonEBSCSIDriverPolicy
+#      AmazonEC2ContainerRegistryReadOnly, AmazonEBSCSIDriver∂Policy
 #    - Purpose: Allows worker nodes to join the cluster and access required AWS services
 #
 # Each role has specific policies attached that grant the minimum necessary permissions
@@ -31,7 +31,6 @@
 # The trust relationships are configured as follows:
 # - DeductiveAssumeRole: Trusted by DeductiveAI AWS account
 # - EKSClusterRole: Trusted by EKS service
-# - EC2Role: Trusted by EC2 service and SecretsReaderRole
 
 provider "aws" {
   region  = var.region

--- a/create_role/modules/deductive_role/outputs.tf
+++ b/create_role/modules/deductive_role/outputs.tf
@@ -20,13 +20,3 @@ output "ec2_role_arn" {
   description = "The ARN of the EC2 instance role"
   value       = aws_iam_role.ec2_role.arn
 }
-
-output "secrets_reader_role_arn" {
-  description = "The ARN of the secrets reader role"
-  value       = aws_iam_role.secrets_reader_role.arn
-}
-
-output "secrets_writer_reader_role_arn" {
-  description = "The ARN of the secrets writer reader role"
-  value       = aws_iam_role.secrets_writer_reader_role.arn
-}

--- a/create_role/modules/deductive_role/variables.tf
+++ b/create_role/modules/deductive_role/variables.tf
@@ -34,7 +34,6 @@ variable "tags" {
 variable "deductive_aws_account_id" {
   description = "Deductive AI's AWS account ID for cross-account permissions"
   type        = string
-  default     = "590183993904"
   sensitive   = true
 }
 


### PR DESCRIPTION
To make the aws secret management easier and robust, this moves the specific secret roles and policies from terraform to pulumi as it makes the provision more dynamic and cleaner. This is the only exception for the role and policy creation due to OIDC provisioned at runtime with EKS.