### PR TITLE
Improve external id for deputy problem + prepare for the launchtemplate policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This configuration creates:
 
 ### Prerequisites
 
-- Terraform v0.14+ installed
+- Terraform version >= 1.11.4 installed
 - AWS CLI configured with appropriate credentials
 
 ### Deployment
@@ -31,6 +31,6 @@ This configuration creates:
 
 ```bash
 terraform init
-terraform plan -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>"
-terraform apply -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>"
+terraform plan -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>" -var "external_id=<external_id_from_deductive_ai>"
+terraform apply -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="deductive_aws_account_id=<deductive_aws_account_id>" -var "external_id=<external_id_from_deductive_ai>"
 ```

--- a/create_role/main.tf
+++ b/create_role/main.tf
@@ -34,7 +34,7 @@ variable "deductive_aws_account_id" {
 }
 
 variable "external_id" {
-  description = "External ID for secure cross-account role assumption (optional but recommended for security)"
+  description = "External ID (unique) for organization or company"
   type        = string
   default     = ""
   sensitive   = true
@@ -47,7 +47,6 @@ module "deductive_role" {
   aws_profile              = var.aws_profile
   deductive_aws_account_id = var.deductive_aws_account_id
   external_id              = var.external_id
-  use_external_id          = var.external_id != "" ? true : false
 
   # Optional: Add additional tags
   # tags = {

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -53,9 +53,9 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
     actions = ["sts:AssumeRole"]
 
-    # Only include the condition if use_external_id is true and external_id is not empty
+    # Only include the condition if external_id is set to avoid the confused deputy problem
     dynamic "condition" {
-      for_each = var.use_external_id && var.external_id != "" ? [1] : []
+      for_each = var.external_id != "" ? [1] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -148,13 +148,14 @@ data "aws_iam_policy_document" "deductive_policy" {
   }
 
   # Second statement is required: RunInstances also requires the
-  # AMI, subnets, SGs, etc. List the resource types you reference
+  # AMI, subnets, SGs, etc.
   statement {
     sid     = "RunViaAllowedTemplateReferencedResources"
     effect  = "Allow"
     actions = ["ec2:RunInstances"]
     resources = [
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:spot-instances-request/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:volume/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:subnet/*",

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -147,6 +147,23 @@ data "aws_iam_policy_document" "deductive_policy" {
     }
   }
 
+  # Perform RunInstances against the instance and spot-instances-request resources (c) syscl
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:spot-instances-request/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
   # Second statement is required: RunInstances also requires the
   # AMI, subnets, SGs, etc.
   statement {
@@ -154,8 +171,6 @@ data "aws_iam_policy_document" "deductive_policy" {
     effect  = "Allow"
     actions = ["ec2:RunInstances"]
     resources = [
-      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
-      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:spot-instances-request/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:volume/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:subnet/*",

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -120,7 +120,6 @@ data "aws_iam_policy_document" "deductive_policy" {
     effect = "Allow"
     actions = [
       "ec2:RebootInstances",
-      "ec2:RunInstances",
     ]
     resources = [
       "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:*/*",
@@ -131,6 +130,37 @@ data "aws_iam_policy_document" "deductive_policy" {
       variable = "aws:ResourceTag/creator"
       values   = ["deductive-ai"]
     }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:launch-template/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Second statement is required: RunInstances also requires the
+  # AMI, subnets, SGs, etc. List the resource types you reference
+  statement {
+    sid     = "RunViaAllowedTemplateReferencedResources"
+    effect  = "Allow"
+    actions = ["ec2:RunInstances"]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:volume/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:subnet/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*",
+      "arn:aws:ec2:*::image/*",
+    ]
   }
 
   # ACM certificate management

--- a/create_role/modules/deductive_role/variables.tf
+++ b/create_role/modules/deductive_role/variables.tf
@@ -44,12 +44,6 @@ variable "external_id" {
   sensitive   = true
 }
 
-variable "use_external_id" {
-  description = "Whether to use external ID for cross-account role assumption"
-  type        = bool
-  default     = false
-}
-
 locals {
   # Standardized tags
   default_tags = {


### PR DESCRIPTION
As part of the improvement of the deputy problem, improves the flow for the Kernel IaC to work with this new condition. Eventually all the customer will have a unique external ID

This change also improves the RunInstances for the launchtemplate, making it restricted in instances and spot-instance request.