### PR TITLE
Refactor Terraform module to improve modularity and security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.terraform
+.terraform.tfstate*
+.terraform.lock.hcl
+*.tfstate
+**/*.tfstate.*

--- a/create_role/README.md
+++ b/create_role/README.md
@@ -1,0 +1,93 @@
+# Deductive AI AWS Bootstrap Roles
+
+This Terraform module creates IAM roles necessary for Deductive AI to operate in your AWS account.
+
+## What this module does
+
+The bootstrap_roles module creates the following IAM roles:
+
+1. **DeductiveAssumeRole** - The main role that DeductiveAI assumes to manage resources
+   - Permissions: EC2, EKS, IAM, ACM, S3, Secrets Manager, and other AWS services
+   - Purpose: Allows DeductiveAI to provision and manage the infrastructure
+
+2. **EKSClusterRole** - Role for EKS cluster with permissions to manage EKS services
+   - Permissions: AmazonEKSClusterPolicy, AmazonEKSServicePolicy
+   - Purpose: Allows the EKS control plane to manage AWS resources on behalf of the cluster
+
+3. **EC2Role** - Role for EC2 instances that run as worker nodes in the EKS cluster
+   - Permissions: AmazonEKSWorkerNodePolicy, AmazonEKS_CNI_Policy, AmazonEC2ContainerRegistryReadOnly, AmazonEBSCSIDriverPolicy
+   - Purpose: Allows worker nodes to join the cluster and access required AWS services
+
+## Usage
+
+```hcl
+provider "aws" {
+  region  = "us-east-2"  # Specify your preferred region
+  profile = "default"    # Specify your AWS profile if not using default
+}
+
+module "bootstrap_roles" {
+  source = "github.com/deductive-ai/deductive-aws-setup//create_role/modules/deductive_role?ref=main"
+
+  # Optional: customize the resource prefix (default is "Deductive")
+  resource_prefix = "Deductive"
+  
+  # These values will be provided by Deductive (required)
+  deductive_aws_account_id = "ACCOUNT_ID_PROVIDED_BY_DEDUCTIVE"  # Will be provided by Deductive
+  external_id              = "EXTERNAL_ID_PROVIDED_BY_DEDUCTIVE" # Will be provided by Deductive
+
+  # Optional: Add additional tags to all created resources
+  additional_tags = {
+    environment = "production"
+    project     = "deductive-integration"
+    owner       = "your-team"
+  }
+}
+
+# Output the ARNs - these need to be shared with Deductive
+output "deductive_role_arn" {
+  description = "The ARN of the Deductive role"
+  value       = module.bootstrap_roles.deductive_role_arn
+}
+
+output "eks_cluster_role_arn" {
+  description = "The ARN of the EKS cluster role"
+  value       = module.bootstrap_roles.eks_cluster_role_arn
+}
+
+output "ec2_role_arn" {
+  description = "The ARN of the EC2 instance role"
+  value       = module.bootstrap_roles.ec2_role_arn
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0.0 |
+| aws | >= 3.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| resource_prefix | Prefix to add to resource names for uniqueness | `string` | `"Deductive"` | no |
+| deductive_aws_account_id | Deductive AI's AWS account ID for cross-account permissions | `string` | n/a | yes |
+| external_id | External ID for secure cross-account role assumption | `string` | `null` | no |
+| additional_tags | Additional tags to apply to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| deductive_role_arn | The ARN of the Deductive role that can be assumed to manage AWS resources |
+| eks_cluster_role_arn | The ARN of the EKS cluster role that allows EKS control plane to manage resources |
+| ec2_role_arn | The ARN of the EC2 instance role for worker nodes in the EKS cluster |
+
+## Security Notes
+
+- Uses external ID to prevent confused deputy problem
+- Has explicit deny statements for admin access
+- Implements least privilege principle with specific resource restrictions
+- Tags all resources with creator="deductive-ai" for tracking and management 

--- a/create_role/modules/deductive_role/locals.tf
+++ b/create_role/modules/deductive_role/locals.tf
@@ -1,0 +1,18 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+locals {
+  # Standardized tags
+  default_tags = {
+    creator = "deductive-ai"
+  }
+
+  # Merge default tags with provided tags
+  resource_tags = merge(local.default_tags, var.additional_tags)
+} 

--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -32,11 +32,6 @@
 # - DeductiveAssumeRole: Trusted by DeductiveAI AWS account
 # - EKSClusterRole: Trusted by EKS service
 
-provider "aws" {
-  region  = var.region
-  profile = var.aws_profile
-}
-
 data "aws_caller_identity" "current" {}
 
 ###########################################
@@ -55,7 +50,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     # Only include the condition if external_id is set to avoid the confused deputy problem
     dynamic "condition" {
-      for_each = var.external_id != "" ? [1] : []
+      for_each = var.external_id != null ? [1] : []
       content {
         test     = "StringEquals"
         variable = "sts:ExternalId"
@@ -505,7 +500,7 @@ resource "aws_iam_policy" "s3_policy" {
       }
     ]
   })
-  tags = local.tags
+  tags = local.resource_tags
 }
 
 ###########################################
@@ -516,7 +511,7 @@ resource "aws_iam_policy" "s3_policy" {
 resource "aws_iam_role" "deductive_role" {
   name               = "${var.resource_prefix}AssumeRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
-  tags               = local.tags
+  tags               = local.resource_tags
 }
 
 # Create an inline policy for Deductive operations
@@ -554,7 +549,7 @@ resource "aws_iam_role" "eks_cluster_role" {
       }
     ]
   })
-  tags = local.tags
+  tags = local.resource_tags
 }
 
 # Attach EKS cluster policies using for_each
@@ -584,7 +579,7 @@ resource "aws_iam_role" "ec2_role" {
       }
     ]
   })
-  tags = local.tags
+  tags = local.resource_tags
 }
 
 # Attach policies to EC2 role using for_each

--- a/create_role/modules/deductive_role/outputs.tf
+++ b/create_role/modules/deductive_role/outputs.tf
@@ -6,17 +6,20 @@
  information and shall use it only in accordance with the terms of
  the license agreement you entered into with Deductive AI, Inc.
 */
+
+# Output the ARNs of the created roles
+
 output "deductive_role_arn" {
-  description = "The ARN of the Deductive role - share this with Deductive"
+  description = "The ARN of the Deductive role that can be assumed to manage AWS resources"
   value       = aws_iam_role.deductive_role.arn
 }
 
 output "eks_cluster_role_arn" {
-  description = "The ARN of the EKS cluster role"
+  description = "The ARN of the EKS cluster role that allows EKS control plane to manage resources"
   value       = aws_iam_role.eks_cluster_role.arn
 }
 
 output "ec2_role_arn" {
-  description = "The ARN of the EC2 instance role"
+  description = "The ARN of the EC2 instance role for worker nodes in the EKS cluster"
   value       = aws_iam_role.ec2_role.arn
 }

--- a/create_role/modules/deductive_role/variables.tf
+++ b/create_role/modules/deductive_role/variables.tf
@@ -7,32 +7,20 @@
  the license agreement you entered into with Deductive AI, Inc.
 */
 
-variable "region" {
-  description = "The AWS region to create resources in"
-  type        = string
-  default     = "us-east-2"
-}
-
-variable "aws_profile" {
-  description = "AWS profile to use as credential"
-  type        = string
-  default     = "default"
-}
-
 variable "resource_prefix" {
   description = "Prefix to add to resource names for uniqueness"
   type        = string
   default     = "Deductive"
 }
 
-variable "tags" {
+variable "additional_tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)
   default     = {}
 }
 
 variable "deductive_aws_account_id" {
-  description = "Deductive AI's AWS account ID for cross-account permissions"
+  description = "Deductive AI's AWS account ID for cross-account permissions (will be provided by Deductive)"
   type        = string
   sensitive   = true
 }
@@ -40,16 +28,7 @@ variable "deductive_aws_account_id" {
 variable "external_id" {
   description = "External ID for secure cross-account role assumption (optional but recommended for security)"
   type        = string
-  default     = "" # Making it optional by providing a default empty value
+  default     = null
+  nullable    = true
   sensitive   = true
-}
-
-locals {
-  # Standardized tags
-  default_tags = {
-    creator = "deductive-ai"
-  }
-
-  # Merge default tags with provided tags
-  tags = merge(local.default_tags, var.tags)
 }

--- a/create_role/modules/deductive_role/versions.tf
+++ b/create_role/modules/deductive_role/versions.tf
@@ -1,0 +1,18 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
+    }
+  }
+} 


### PR DESCRIPTION
This PR restructures the Deductive AWS roles module to follow Terraform best practices:
## Key improvements:
- Removed provider configuration from the module (now inherited from caller)
- Renamed module to bootstrap_roles to better reflect its purpose
- Made deductive_aws_account_id a variable instead of hardcoded value for security
- Changed external_id parameter to use nullable type instead of empty string
- Renamed tags variables to avoid confusion with AWS provider defaults
- Created proper module structure with separate files for versions, locals, variables, and outputs
- Added comprehensive README with usage examples and documentation
## Security enhancements:
- Removed hardcoded account ID from public repository
- Improved input validation for sensitive parameters
- Maintained all existing security policies and restrictions

## Testing:
apply the change, nothing change:
```

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:
```

Noted: to migrate the module due to the following error:
```
Error: Provider configuration not present
│ 
│ To work with module.deductive_role.aws_iam_role_policy.secrets_management_policy (orphan) its original provider configuration at
│ module.deductive_role.provider["registry.terraform.io/hashicorp/aws"] is required, but it has been removed. This occurs when a
│ provider configuration is removed while objects created by that provider still exist in the state. Re-add the provider
│ configuration to destroy module.deductive_role.aws_iam_role_policy.secrets_management_policy (orphan), after which you can remove
│ the provider configuration again.
```

```
❯ terraform state list | grep module.deductive_role
module.deductive_role.data.aws_caller_identity.current
module.deductive_role.data.aws_iam_policy_document.assume_role_policy
module.deductive_role.data.aws_iam_policy_document.deductive_policy
module.deductive_role.data.aws_iam_policy_document.secrets_managemen

...
❯ terraform state mv module.deductive_role module.bootstrap_roles

...

❯ terraform state list | grep module.bootstrap_roles
module.bootstrap_roles.data.aws_caller_identity.current
module.bootstrap_roles.data.aws_iam_policy_document.assume_role_policy
module.bootstrap_roles.data.aws_iam_policy_document.deductive_policy
module.bootstrap_roles.data.aws_iam_policy_document.secrets_management_policy
module.bootstrap_roles.aws_iam_policy.s3_po
```