### PR TITLE
Refactor AWS IAM modules to standard Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
 # Deductive AI AWS Integration
 
-This Terraform configuration creates the necessary AWS resources for integrating Deductive AI with your AWS account.
+This Terraform module repository creates the necessary AWS resources for integrating Deductive AI with your AWS account.
 
 ## Overview
 
-This configuration creates:
+The repository is organized into Terraform modules that can be easily referenced:
 
-1. An IAM role that Deductive AI can assume to manage resources in your AWS account
-2. A Secrets Manager secret for storing configuration data
-3. Necessary policies with least-privilege permissions
+```
+modules/
+  bootstrap/  # Core IAM roles and policies for Deductive AI integration
+```
 
-## Security Considerations
+## Module Usage
 
-- All resources created by Deductive AI are tagged with `creator = "deductive-ai"`
-- IAM permissions are scoped to only the resources that Deductive AI needs to manage
-- The role can only be assumed by the Deductive AI AWS account
+### As a Module Reference
 
-## Usage
+You can reference the modules directly in your own Terraform configurations:
 
-### Prerequisites
+```hcl
+module "deductive_bootstrap" {
+  source = "git::https://github.com/deductive-ai/aws-setup.git//modules/bootstrap?ref=v1.0.0"
+  
+  role_info = {
+    resource_prefix         = "Deductive"
+    external_id             = "your-external-id"              # Provided by Deductive AI
+    deductive_aws_account_id = "deductive-aws-account-number" # Provided by Deductive AI
+  }
+}
+```
 
-- Terraform version >= 1.11.4 installed
-- AWS CLI configured with appropriate credentials
+### Standalone Usage
 
-### Deployment
+You can also use the root configuration directly:
 
 1. Clone this repository
 2. Navigate to the repository directory
@@ -35,4 +43,9 @@ terraform plan -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var=
 terraform apply -var="region=<aws_region>" -var="aws_profile=<aws_profile>" -var="external_id=<external_id_from_deductive_ai>"
 ```
 
-Note: If you need to override `deductive_aws_account`, you can add `-var="deductive_aws_account_id=<custom_account_id>"` to the commands above.
+## Security Considerations
+
+- All resources created by Deductive AI are tagged with `creator = "deductive-ai"`
+- IAM permissions are scoped to only the resources that Deductive AI needs to manage
+- The role can only be assumed by the Deductive AI AWS account
+- External ID is used to prevent confused deputy problems

--- a/create_role/main.tf
+++ b/create_role/main.tf
@@ -49,11 +49,13 @@ variable "deductive_aws_account_id" {
 }
 
 module "bootstrap_roles" {
-  source = "./modules/deductive_role"
+  source = "../modules/bootstrap"
 
-  resource_prefix        = "Deductive"  # Can be customized if needed
-  external_id            = var.external_id
-  deductive_aws_account_id = var.deductive_aws_account_id
+  role_info = {
+    resource_prefix         = "Deductive"
+    external_id             = var.external_id
+    deductive_aws_account_id = var.deductive_aws_account_id
+  }
 
   # Additional tags that will be applied to all resources
   additional_tags = {}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,55 @@
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}
+
+variable "region" {
+  description = "The AWS region to create resources in"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "aws_profile" {
+  description = "AWS profile to use as credential"
+  type        = string
+  default     = "default"
+}
+
+module "bootstrap" {
+  source = "./modules/bootstrap"
+
+  role_info = {
+    resource_prefix         = "Deductive"
+    external_id             = var.external_id
+    deductive_aws_account_id = var.deductive_aws_account_id
+  }
+
+  # Additional tags that will be applied to all resources
+  additional_tags = {}
+}
+
+# External ID and AWS account ID
+variable "external_id" {
+  description = "External ID (unique) for organization or company"
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "deductive_aws_account_id" {
+  description = "Deductive AI's AWS account ID(s)"
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+output "share_with_deductive" {
+  description = "The ARNs of the resources to share with Deductive"
+  value = {
+    "deductive_role_arn"   = module.bootstrap.deductive_role_arn
+    "eks_cluster_role_arn" = module.bootstrap.eks_cluster_role_arn
+    "ec2_role_arn"         = module.bootstrap.ec2_role_arn
+  }
+} 

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -1,0 +1,54 @@
+# Bootstrap Module
+
+This module provides the core infrastructure required for Deductive AI to operate in your AWS account. It creates the necessary IAM roles with appropriate permissions for secure cross-account access.
+
+## Resources Created
+
+- **DeductiveAssumeRole**: Main role that Deductive AI will assume to manage resources
+- **EKS Cluster Role**: Role for EKS cluster with permissions to manage EKS services
+- **EC2 Role**: Role for EC2 instances that run as worker nodes in the EKS cluster
+
+## Usage
+
+```hcl
+module "bootstrap" {
+  source = "git::https://github.com/deductive-ai/aws-setup.git//modules/bootstrap?ref=v1.0.0"
+
+  role_info = {
+    resource_prefix         = "Deductive"
+    external_id             = "your-external-id"              # Optional but recommended for security
+    deductive_aws_account_id = "deductive-aws-account-number" # Will be provided by Deductive AI
+  }
+
+  # Optional additional tags for resources
+  additional_tags = {
+    Environment = "Production"
+    Owner       = "DevOps"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| role_info | Object containing role configuration | object | See below | yes |
+| additional_tags | Additional tags to apply to all resources | map(string) | {} | no |
+
+### role_info Object Structure
+
+```hcl
+role_info = {
+  resource_prefix         = string
+  external_id             = optional(string, null)
+  deductive_aws_account_id = optional(string, null)
+}
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| deductive_role_arn | The ARN of the Deductive role |
+| eks_cluster_role_arn | The ARN of the EKS cluster role |
+| ec2_role_arn | The ARN of the EC2 role | 

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -1,0 +1,614 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+# The purpose of this module is to create a role for Deductive AI to perform aws resource provisioning.
+# This role can then be assumed by Deductive AI to deploy services
+# necessary for its operations in the Customer's AWS account.
+
+data "aws_caller_identity" "current" {}
+
+# Use local variables to unpack and set defaults for the role_info input
+locals {
+  resource_prefix         = var.role_info.resource_prefix
+  external_id             = var.role_info.external_id
+  deductive_aws_account_id = var.role_info.deductive_aws_account_id != null ? var.role_info.deductive_aws_account_id : "PLACEHOLDER_ACCOUNT_ID"
+}
+
+###########################################
+# POLICY DOCUMENTS (IAM Policy Definitions)
+###########################################
+
+# Define the assume role policy document with optional external ID
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.deductive_aws_account_id}:root"]
+    }
+    actions = ["sts:AssumeRole"]
+
+    # Only include the condition if external_id is set to avoid the confused deputy problem
+    dynamic "condition" {
+      for_each = local.external_id != null ? toset(["include"]) : toset([])
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [local.external_id]
+      }
+    }
+  }
+}
+
+# Define the main policy document for Deductive operations
+data "aws_iam_policy_document" "deductive_policy" {
+  # Read-only permissions for various AWS services
+  statement {
+    effect = "Allow"
+    actions = [
+      # EC2 Read-Only Actions
+      "ec2:Describe*",
+      "ec2:Get*",
+      "ec2:List*",
+      # ELB Read-Only Actions
+      "elasticloadbalancing:Describe*",
+      # EKS Read-Only Actions
+      "eks:Describe*",
+      "eks:List*",
+      # IAM Read-Only Actions
+      "iam:GetRole",
+      "iam:GetInstanceProfile",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListEntitiesForPolicy",
+      "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
+      "iam:ListPolicyVersions",
+      "iam:CreatePolicyVersion",
+      # For nodegroup creation
+      "iam:CreateServiceLinkedRole",
+      # ACM Read-Only Actions
+      "acm:Describe*",
+      "acm:List*"
+    ]
+    resources = ["*"]
+  }
+
+  # Create Deductive SSL certificate for SSO
+  statement {
+    effect = "Allow"
+    actions = [
+      "acm:RequestCertificate"
+    ]
+    resources = ["arn:aws:acm:*:${data.aws_caller_identity.current.account_id}:certificate/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Create permission to run instances
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RebootInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:*/*",
+      "arn:aws:ec2:*::image/ami-*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:launch-template/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Perform RunInstances against the instance and spot-instances-request resources
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:spot-instances-request/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Second statement is required: RunInstances also requires the
+  # AMI, subnets, SGs, etc.
+  statement {
+    sid     = "RunViaAllowedTemplateReferencedResources"
+    effect  = "Allow"
+    actions = ["ec2:RunInstances"]
+    resources = [
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:volume/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:network-interface/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:subnet/*",
+      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*",
+      "arn:aws:ec2:*::image/*",
+    ]
+  }
+
+  # ACM certificate management
+  statement {
+    effect = "Allow"
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:DeleteCertificate",
+      "acm:AddTagsToCertificate",
+      "acm:RemoveTagsFromCertificate",
+      "acm:ListTagsForCertificate"
+    ]
+    resources = ["arn:aws:acm:*:${data.aws_caller_identity.current.account_id}:certificate/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Allow permissions to create resources for EC2 and VPC
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AllocateAddress",
+      "ec2:CreateLaunchTemplate",
+      "ec2:CreateInternetGateway",
+      "ec2:CreateNatGateway",
+      "ec2:CreateVpc",
+      "ec2:CreateVpcPeeringConnection",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSubnet",
+      "ec2:CreateRouteTable",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteVolume",
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+      "ec2:ModifyVolume",
+      "ec2:DescribeVolumes"
+    ]
+    resources = ["arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # EC2 and VPC management
+  statement {
+    effect = "Allow"
+    actions = [
+      # Creation of Resources
+      "ec2:AssociateRouteTable",
+      "ec2:AttachInternetGateway",
+      "ec2:CreateKeyPair",
+      "ec2:CreateNatGateway",
+      "ec2:CreateRoute",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSubnet",
+      "ec2:CreateRouteTable",
+      # Required to terminate, reboot, stop and start instances
+      "ec2:TerminateInstances",
+      "ec2:RebootInstances",
+      "ec2:StopInstances",
+      "ec2:StartInstances",
+      # Required for modifications of the resources
+      "ec2:Modify*",
+      "ec2:Delete*",
+      "ec2:Disassociate*",
+      "ec2:Detach*",
+      "ec2:Unassign*",
+      "ec2:ReleaseAddress"
+    ]
+    resources = ["arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # EIP management
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DisassociateAddress"
+    ]
+    # The Amazon Resource Name (ARN) format for an Elastic IP (EIP) in AWS does not follow the
+    # typical resource-specific ARN format used for other resources like instances, volumes, etc.
+    # This is because EIPs do not have a direct ARN representation in the same way other EC2 resources do.
+    # Instead, permissions for actions involving EIPs, like ec2:DisassociateAddress, are generally specified
+    # with wildcards and conditions.
+    resources = ["*"]
+    # condition {
+    #   test     = "StringEquals"
+    #   variable = "aws:ResourceTag/creator"
+    #   values   = ["deductive-ai"]
+    # }
+  }
+
+  # Security group management
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags",
+      "ec2:RevokeSecurityGroupIngress",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:DeleteSecurityGroup",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:AuthorizeSecurityGroupEgress"
+    ]
+    resources = ["arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # EKS management
+  statement {
+    effect = "Allow"
+    actions = [
+      "eks:Create*",
+      "eks:Delete*",
+      "eks:Update*",
+      "eks:DeregisterCluster",
+      "eks:RegisterCluster",
+      "eks:TagResource",
+      "eks:UntagResource"
+    ]
+    resources = ["arn:aws:eks:*:${data.aws_caller_identity.current.account_id}:*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # S3 bucket management
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:CreateBucket",
+      "s3:List*",
+      "s3:Get*",
+      "s3:Put*",
+      "s3:Delete*",
+    ]
+    resources = ["arn:aws:s3:::deductiveai-*"]
+  }
+
+  # IAM PassRole and UntagRole
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PassRole",
+      "iam:UntagRole",
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*Deductive*"
+    ]
+  }
+
+  # OpenIDConnect provider listing
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:ListOpenIDConnectProviders"
+    ]
+    resources = ["*"]
+  }
+
+  # OpenIDConnect provider management
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.eks.*.amazonaws.com/id/*"]
+  }
+
+  # IAM role and policy management permissions
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:AddRoleToInstanceProfile",
+      "iam:AttachRolePolicy",
+      "iam:CreateInstanceProfile",
+      "iam:CreatePolicy",
+      "iam:CreateRole",
+      "iam:CreateServiceLinkedRole",
+      "iam:DeleteInstanceProfile",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:DetachRolePolicy",
+      "iam:RemoveRoleFromInstanceProfile",
+      "iam:TagPolicy",
+      "iam:TagRole",
+      "iam:UpdateAssumeRolePolicy"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*Deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*Deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*deductive*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*Deductive*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
+  # Explicitly deny attaching admin policies
+  statement {
+    effect = "Deny"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:PutRolePolicy"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "ArnLike"
+      variable = "iam:PolicyArn"
+      values = [
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+        "arn:aws:iam::aws:policy/*Admin*",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*Admin*"
+      ]
+    }
+  }
+  # Prevent creating policies with * permissions
+  statement {
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:CreatePolicyVersion"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "iam:PolicyDocument"
+      values = [
+        "*\"Action\":[\"*\"]",
+        "*\"Action\":\"*\"",
+        "*\"Action\":[\"iam:*\"]",
+        "*\"Action\":\"iam:*\""
+      ]
+    }
+  }
+
+  # Allow managing role policies for secrets roles
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PutRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:DeleteRolePolicy"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.resource_prefix}*SecretsReaderRole",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.resource_prefix}*SecretsWriterReaderRole",
+    ]
+  }
+}
+
+# Define the secrets management policy document
+data "aws_iam_policy_document" "secrets_management_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:CreateSecret",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecret",
+      "secretsmanager:TagResource",
+      "secretsmanager:UntagResource",
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:PutResourcePolicy",
+      "secretsmanager:DeleteSecret"
+    ]
+    resources = ["arn:aws:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:deductiveai-*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+}
+
+###########################################
+# STANDALONE IAM POLICIES
+###########################################
+
+# Create a policy for S3 access
+resource "aws_iam_policy" "s3_policy" {
+  name        = "${local.resource_prefix}S3Policy"
+  description = "Policy for EC2 to access S3"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          "arn:aws:s3:::deductiveai-*",
+          "arn:aws:s3:::deductiveai-*/*"
+        ]
+      }
+    ]
+  })
+
+  tags = merge(
+    var.additional_tags,
+    {
+      creator     = "deductive-ai"
+    }
+  )
+}
+
+###########################################
+# IAM ROLES AND POLICY ATTACHMENTS
+###########################################
+
+# Create the main Deductive role
+resource "aws_iam_role" "deductive_role" {
+  name               = "${local.resource_prefix}AssumeRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  tags = merge(
+    var.additional_tags,
+    {
+      creator     = "deductive-ai"
+    }
+  )
+}
+
+# Attach the Deductive policy to the role
+resource "aws_iam_role_policy" "deductive_policy" {
+  name   = "${local.resource_prefix}Policy"
+  role   = aws_iam_role.deductive_role.id
+  policy = data.aws_iam_policy_document.deductive_policy.json
+}
+
+# Attach the secrets management policy to the role
+resource "aws_iam_role_policy" "secrets_management_policy" {
+  name   = "${local.resource_prefix}SecretsManagementPolicy"
+  role   = aws_iam_role.deductive_role.id
+  policy = data.aws_iam_policy_document.secrets_management_policy.json
+}
+
+# Attach the EBS CSI driver policy to the role
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver_policy_attachment" {
+  role       = aws_iam_role.deductive_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# Create the EKS cluster role
+resource "aws_iam_role" "eks_cluster_role" {
+  name = "${local.resource_prefix}EKSClusterRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(
+    var.additional_tags,
+    {
+      creator     = "deductive-ai"
+    }
+  )
+}
+
+# Attach the necessary policies to the EKS cluster role
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy_attachments" {
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
+    "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+  ])
+
+  role       = aws_iam_role.eks_cluster_role.name
+  policy_arn = each.value
+}
+
+# Create the EC2 role for worker nodes
+resource "aws_iam_role" "ec2_role" {
+  name = "${local.resource_prefix}EC2Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(
+    var.additional_tags,
+    {
+      creator     = "deductive-ai"
+    }
+  )
+}
+
+# Attach the necessary policies to the EC2 role
+resource "aws_iam_role_policy_attachment" "ec2_policy_attachments" {
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  ])
+
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = each.value
+}
+
+# Attach the S3 policy to the EC2 role
+resource "aws_iam_role_policy_attachment" "ec2_s3_policy_attachment" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
+} 

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -17,7 +17,7 @@ data "aws_caller_identity" "current" {}
 locals {
   resource_prefix         = var.role_info.resource_prefix
   external_id             = var.role_info.external_id
-  deductive_aws_account_id = var.role_info.deductive_aws_account_id != null ? var.role_info.deductive_aws_account_id : "PLACEHOLDER_ACCOUNT_ID"
+  deductive_aws_account_id = var.role_info.deductive_aws_account_id != null ? var.role_info.deductive_aws_account_id : "590183993904"
 }
 
 ###########################################

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,0 +1,25 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+# Output the ARNs of the created roles
+
+output "deductive_role_arn" {
+  description = "The ARN of the Deductive role that can be assumed to manage AWS resources"
+  value       = aws_iam_role.deductive_role.arn
+}
+
+output "eks_cluster_role_arn" {
+  description = "The ARN of the EKS cluster role that allows EKS control plane to manage resources"
+  value       = aws_iam_role.eks_cluster_role.arn
+}
+
+output "ec2_role_arn" {
+  description = "The ARN of the EC2 instance role for worker nodes in the EKS cluster"
+  value       = aws_iam_role.ec2_role.arn
+} 

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+variable "role_info" {
+  description = "Information required for role creation"
+  type = object({
+    resource_prefix         = string
+    external_id             = optional(string, null)
+    deductive_aws_account_id = optional(string, null)
+  })
+  default = {
+    resource_prefix = "Deductive"
+  }
+}
+
+variable "additional_tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+} 

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,0 +1,19 @@
+/*
+ Copyright (c) 2023, Deductive AI, Inc. All rights reserved.
+
+ This software is the confidential and proprietary information of
+ Deductive AI, Inc. You shall not disclose such confidential
+ information and shall use it only in accordance with the terms of
+ the license agreement you entered into with Deductive AI, Inc.
+*/
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+} 


### PR DESCRIPTION
This PR restructures our Terraform codebase to follow standard Terraform module organizational practices, as suggested in recent customer feedback. The changes maintain full backward compatibility while improving the reusability and maintainability of our modules.
Changes
Relocated modules from create_role/modules/deductive_role to the root-level modules/bootstrap
Consolidated input variables using object-based pattern for better organization:
```
Apply to main.tf
  variable "role_info" {
    type = object({
      resource_prefix         = string
      external_id             = optional(string, null)
      deductive_aws_account_id = optional(string, null)
    })
  }
```
- Updated module references to use the standard Terraform module source format
- Created detailed README documentation in the bootstrap module
- Maintained backward compatibility with existing IAM role policies and permissions
-[ Verified zero infrastructure changes when applying the refactored code

tested=```
> terraform state mv module.bootstrap_roles module.bootstrap

> terraform apply ...
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
