### PR TITLE
Add support for cluster horizontal pod scaling + interruption queue (sqs) + inline polices

### DIFF
--- a/create_role/modules/deductive_role/main.tf
+++ b/create_role/modules/deductive_role/main.tf
@@ -589,7 +589,8 @@ resource "aws_iam_role_policy_attachment" "ec2_policy_attachments" {
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   ])
 
   role       = aws_iam_role.ec2_role.name

--- a/main.tf
+++ b/main.tf
@@ -22,10 +22,18 @@ module "bootstrap" {
     resource_prefix         = "Deductive"
     external_id             = var.external_id
     deductive_aws_account_id = var.deductive_aws_account_id
+    cluster_name            = var.cluster_name
   }
 
   # Additional tags that will be applied to all resources
   additional_tags = {}
+}
+
+variable "cluster_name" {
+  description = "Cluster name for the provisioned eks"
+  type        = string
+  default     = null
+  nullable    = true
 }
 
 # External ID and AWS account ID

--- a/main.tf
+++ b/main.tf
@@ -22,18 +22,10 @@ module "bootstrap" {
     resource_prefix         = "Deductive"
     external_id             = var.external_id
     deductive_aws_account_id = var.deductive_aws_account_id
-    cluster_name            = var.cluster_name
   }
 
   # Additional tags that will be applied to all resources
   additional_tags = {}
-}
-
-variable "cluster_name" {
-  description = "Cluster name for the provisioned eks"
-  type        = string
-  default     = null
-  nullable    = true
 }
 
 # External ID and AWS account ID

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -16,14 +16,13 @@ module "bootstrap" {
 
   role_info = {
     resource_prefix         = "Deductive"
-    external_id             = "your-external-id"              # Optional but recommended for security
+    external_id             = "<external_id_from_deductive>"              # Optional but recommended for security
     deductive_aws_account_id = "deductive-aws-account-number" # Will be provided by Deductive AI
   }
 
   # Optional additional tags for resources
   additional_tags = {
     Environment = "Production"
-    Owner       = "DevOps"
   }
 }
 ```
@@ -51,4 +50,4 @@ role_info = {
 |------|-------------|
 | deductive_role_arn | The ARN of the Deductive role |
 | eks_cluster_role_arn | The ARN of the EKS cluster role |
-| ec2_role_arn | The ARN of the EC2 role | 
+| ec2_role_arn | The ARN of the EC2 role |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -16,7 +16,6 @@ module "bootstrap" {
 
   role_info = {
     resource_prefix         = "Deductive"
-    cluster_name            = "customer-cluster-name"
     external_id             = "<external_id_from_deductive>"              # Optional but recommended for security
     deductive_aws_account_id = "deductive-aws-account-number" # Will be provided by Deductive AI
   }
@@ -32,7 +31,7 @@ module "bootstrap" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|----------|
-| role_info | Object containing role configuration including required cluster_name field | object | See below | yes |
+| role_info | Object containing role configuration | object | See below | yes |
 | additional_tags | Additional tags to apply to all resources | map(string) | {} | no |
 
 ### role_info Object Structure
@@ -40,7 +39,6 @@ module "bootstrap" {
 ```hcl
 role_info = {
   resource_prefix         = string
-  cluster_name            = string
   external_id             = optional(string, null)
   deductive_aws_account_id = optional(string, null)
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -16,6 +16,7 @@ module "bootstrap" {
 
   role_info = {
     resource_prefix         = "Deductive"
+    cluster_name            = "customer-cluster-name"
     external_id             = "<external_id_from_deductive>"              # Optional but recommended for security
     deductive_aws_account_id = "deductive-aws-account-number" # Will be provided by Deductive AI
   }
@@ -31,7 +32,7 @@ module "bootstrap" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|----------|
-| role_info | Object containing role configuration | object | See below | yes |
+| role_info | Object containing role configuration including required cluster_name field | object | See below | yes |
 | additional_tags | Additional tags to apply to all resources | map(string) | {} | no |
 
 ### role_info Object Structure
@@ -39,6 +40,7 @@ module "bootstrap" {
 ```hcl
 role_info = {
   resource_prefix         = string
+  cluster_name            = string
   external_id             = optional(string, null)
   deductive_aws_account_id = optional(string, null)
 }

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -265,6 +265,7 @@ data "aws_iam_policy_document" "deductive_policy" {
     effect = "Allow"
     actions = [
       "ec2:CreateTags",
+      "ec2:DeleteTags",
       "ec2:RevokeSecurityGroupIngress",
       "ec2:RevokeSecurityGroupEgress",
       "ec2:DeleteSecurityGroup",
@@ -288,21 +289,22 @@ data "aws_iam_policy_document" "deductive_policy" {
   }
 
   # Security group management for EKS clusters
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:CreateTags",
-      "ec2:DeleteTags",
-    ]
-    resources = [
-      "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*"
-    ]
-    condition {
-      test     = "StringLike"
-      variable = "aws:ResourceTag/aws:eks:cluster-name"
-      values   = ["${var.role_info.cluster_name}*"]
-    }
-  }
+  # statement {
+  #   effect = "Allow"
+  #   actions = [
+  #     "ec2:CreateTags",
+  #     "ec2:DeleteTags",
+  #   ]
+  #   resources = [
+  #     "arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:security-group/*"
+  #   ]
+  #   condition {
+  #     test     = "StringLike"
+  #     variable = "aws:ResourceTag/aws:eks:cluster-name"
+  #     # Right now we only have the cluster name for restriction, currently just use *
+  #     values   = ["*"]
+  #   }
+  # }
 
   # Allow Karpenter to read from DeductiveAI's scaling SQS
   statement {

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -11,7 +11,6 @@ variable "role_info" {
   description = "Information required for role creation"
   type = object({
     resource_prefix          = optional(string, "Deductive")
-    cluster_name             = optional(string, null)
     external_id              = optional(string, null)
     deductive_aws_account_id = optional(string, null)
   })

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -10,8 +10,9 @@
 variable "role_info" {
   description = "Information required for role creation"
   type = object({
-    resource_prefix         = optional(string, "Deductive")
-    external_id             = optional(string, null)
+    resource_prefix          = optional(string, "Deductive")
+    cluster_name             = optional(string, null)
+    external_id              = optional(string, null)
     deductive_aws_account_id = optional(string, null)
   })
   default = {}
@@ -21,4 +22,4 @@ variable "additional_tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)
   default     = {}
-} 
+}


### PR DESCRIPTION
This patch mainly introduces the Kapenter auto pod scaling permission set:
1. Proper permissions/policies for Karpenter controller
2. Interruption queue (SQS) polices
3. Inline ec2 role polices for better maintainability 