### PR TITLE
Fix resource_prefix issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can reference the modules directly in your own Terraform configurations:
 
 ```hcl
 module "deductive_bootstrap" {
-  source = "git::https://github.com/deductive-ai/aws-setup.git//modules/bootstrap?ref=v1.0.0"
+  source = "git::https://github.com/deductive-ai/aws-setup.git//modules/bootstrap?ref=v1.0.2"
   
   role_info = {
     resource_prefix         = "Deductive"

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -10,13 +10,11 @@
 variable "role_info" {
   description = "Information required for role creation"
   type = object({
-    resource_prefix         = string
+    resource_prefix         = optional(string, "Deductive")
     external_id             = optional(string, null)
     deductive_aws_account_id = optional(string, null)
   })
-  default = {
-    resource_prefix = "Deductive"
-  }
+  default = {}
 }
 
 variable "additional_tags" {


### PR DESCRIPTION
```
module.bootstrap_roles.aws_iam_policy.s3_policy: Creating...
module.bootstrap_roles.aws_iam_role.deductive_role: Creating...
module.bootstrap_roles.aws_iam_role.eks_cluster_role: Creating...
module.bootstrap_roles.aws_iam_role.ec2_role: Creating...
╷
│ Error: creating IAM Policy (DeductiveS3Policy): operation error IAM: CreatePolicy, https response error StatusCode: 409, RequestID: a80d1ab3-c677-4f5f-bf59-908a91ddeaed, EntityAlreadyExists: A policy called DeductiveS3Policy already exists. Duplicate names are not allowed.
│
│   with module.bootstrap_roles.aws_iam_policy.s3_policy,
│   on ../modules/bootstrap/main.tf line 468, in resource "aws_iam_policy" "s3_policy":
│  468: resource "aws_iam_policy" "s3_policy" {
│
╵
╷
│ Error: creating IAM Role (DeductiveAssumeRole): operation error IAM: CreateRole, https response error StatusCode: 409, RequestID: 57de4658-175e-4fda-affb-46ffa5070666, EntityAlreadyExists: Role with name DeductiveAssumeRole already exists.
│
│   with module.bootstrap_roles.aws_iam_role.deductive_role,
│   on ../modules/bootstrap/main.tf line 503, in resource "aws_iam_role" "deductive_role":
│  503: resource "aws_iam_role" "deductive_role" {
│
╵
╷
│ Error: creating IAM Role (DeductiveEKSClusterRole): operation error IAM: CreateRole, https response error StatusCode: 409, RequestID: 745113f3-b479-40af-91eb-51e5da47579a, EntityAlreadyExists: Role with name DeductiveEKSClusterRole already exists.
│
│   with module.bootstrap_roles.aws_iam_role.eks_cluster_role,
│   on ../modules/bootstrap/main.tf line 535, in resource "aws_iam_role" "eks_cluster_role":
│  535: resource "aws_iam_role" "eks_cluster_role" {
│
╵
╷
│ Error: creating IAM Role (DeductiveEC2Role): operation error IAM: CreateRole, https response error StatusCode: 409, RequestID: ffa47ea0-bce7-4087-96d9-55a3df575034, EntityAlreadyExists: Role with name DeductiveEC2Role already exists.
│
│   with module.bootstrap_roles.aws_iam_role.ec2_role,
│   on ../modules/bootstrap/main.tf line 572, in resource "aws_iam_role" "ec2_role":
│  572: resource "aws_iam_role" "ec2_role" {
│
╵
```