### PR TITLE
Support launch template (version) update

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -207,6 +207,19 @@ data "aws_iam_policy_document" "deductive_policy" {
     }
   }
 
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateLaunchTemplateVersion"
+    ]
+    resources = ["arn:aws:ec2:*:${data.aws_caller_identity.current.account_id}:launch-template/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/creator"
+      values   = ["deductive-ai"]
+    }
+  }
+
   # EC2 and VPC management
   statement {
     effect = "Allow"


### PR DESCRIPTION
This brings the support when ec2:Launchtemplate gots updated for deductive lt.

Tested plan:
1. Change the launch template in IaC
2. Apply the IaC update
3. Verify the policy inline created
<img width="1650" alt="image" src="https://github.com/user-attachments/assets/ae39d0dd-b5b9-4e12-a8d7-cd27cab43046" />
4. verify the policies gone away since it is inlined now
<img width="2162" alt="image" src="https://github.com/user-attachments/assets/4772f1ae-d4ff-48e3-be63-57a6f78aa41d" />
5. Verify the secrets still accessible in Amazon Secret Management volume mount
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/0ad66ae0-c65d-4a80-8242-fc824b386af2" />
