### PR TITLE
Switch back to use IaC to provision EC2 and EKS role

### DIFF
--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: ">= 1.12.0"
+        terraform_version: ">= 1.12.1"
 
     - uses: terraform-linters/setup-tflint@v4
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,43 @@
+# (Optional) Sync state to S3 bucket
+Optionally, you can save terraform state to s3 bucket.
+1. explicitly defined the backend in providers.tf, otherwise you will see terraform raised warning about `-backend-config was used without a "backend" block in the configuration.`
+```hcl
+terraform {
+  backend "s3" {
+    bucket  = <bucket>
+    key     = "terraform.tfstate"
+    region  = <region>
+    encrypt = true
+  }
+}
+```
+2. Migrate the state from local to s3 (note you may need to switch workspace (via tenant) if you are under multitenant environment `terraform workspace select <tenant>`), then
+```bash
+terraform init
+```
+3. Create new workspace
+```bash
+terraform workspace new <tenant>
+4. Plan the change
+```bash
+ terraform plan -var="tenant=<tenant>" -var="region=<region>" -var="aws_profile=<profile>"
+```
+5. Apply if things looks sanity
+```bash
+ terraform apply -var="tenant=<tenant>" -var="region=<region>" -var="aws_profile=<profile>"
+```
+if you see `Role with name <name> already exists`, import it:
+```bash
+TENANT=<tenant>
+AWS_PROFILE=<profile>
+AWS_REGION=<region>
+
+terraform import -var="tenant=$TENANT" -var="aws_profile=$AWS_PROFILE" -var="region=$AWS_REGION" module.bootstrap.aws_iam_role.deductive_role DeductiveAssumeRole-${TENANT}
+```
+
+# Common FAQ
+If you see terraform version issue, please refer to [terraform](https://developer.hashicorp.com/terraform/install)
+for installing the latest version.
+
+# Development
+If you want to submit the change, don't forget to install `tflint`, `tfsec`, and `checkov`.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ Outputs:
 
 share_with_deductive = {
   "aws_region" = "us-west-1"
-  "deductive_role_arn"   = "arn:aws:iam::123456789012:role/DeductiveAssumeRole"
-  "eks_cluster_role_arn" = "arn:aws:iam::123456789012:role/DeductiveAIEKSClusterRole"
-  "ec2_role_arn"         = "arn:aws:iam::123456789012:role/DeductiveAIEC2Role-tenant"
+  "deductive_role_arn"   = "arn:aws:iam::123456789012:role/DeductiveAssumeRole-<tenant>"
+  "aws_setup_version"    = "<version>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ terraform import -var="tenant=$TENANT" -var="aws_profile=$AWS_PROFILE" -var="reg
 # Common FAQ
 If you see terraform version issue, please refer to [terraform](https://developer.hashicorp.com/terraform/install)
 for installing the latest version.
+
+# Development
+If you want to submit the change, don't forget to install `tflint`, `tfsec`, and `checkov`.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,54 @@
 # Deductive AI AWS Integration
 
-Set up AWS integration for Deductive AI in three simple steps:
+This repository contains Terraform configurations to set up AWS integration for Deductive AI.
 
-1. Clone this repository
-2. Run:
+## Prerequisites
 
-```bash
-terraform init
-terraform plan -var="tenant=<tenant>" -var="external_id=<external_id_from_deductive_ai>"
-terraform apply -var="tenant=<tenant>" -var="external_id=<external_id_from_deductive_ai>"
-```
+- Terraform installed (version 1.12.1 or later)
+- External ID provided by Deductive AI
+- Tenant identifier for your organization
 
-3. Share the role ARNs from the output with Deductive AI
+## Quick Start
 
-Example output:
+1. **Clone this repository**
+   ```bash
+   git clone https://github.com/deductive-ai/aws-setup.git
+   cd aws-setup
+   ```
 
-```bash
-Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+2. **Initialize and apply the configuration**
+   ```bash
+   terraform init
+   terraform plan \
+     -var="tenant=<your-tenant-id>" \
+     -var="external_id=<external-id-from-deductive>" \
+     -var="region=<aws-region>" \
+     -var="aws_profile=<your-aws-profile>"
+   ```
 
-Outputs:
+   > **Note:** Review the plan output above. If everything looks correct, proceed with the apply command.
 
-share_with_deductive = {
-  "aws_region" = "us-west-1"
-  "deductive_role_arn"   = "arn:aws:iam::123456789012:role/DeductiveAssumeRole-<tenant>"
-  "aws_setup_version"    = "<version>"
-}
-```
+   ```bash
+   terraform apply \
+     -var="tenant=<your-tenant-id>" \
+     -var="external_id=<external-id-from-deductive>" \
+     -var="region=<aws-region>" \
+     -var="aws_profile=<your-aws-profile>"
+   ```
 
-You'll need:
+3. **Share the output with Deductive AI**
+   
+   After successful deployment, you'll receive output similar to:
+   ```bash
+   Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
 
-- External ID (provided by Deductive AI)
+   Outputs:
 
-Optional parameters:
+   share_with_deductive = {
+     "aws_region" = "us-west-1"
+     "deductive_role_arn" = "arn:aws:iam::123456789012:role/DeductiveAssumeRole-<tenant>"
+     "release_version" = "v1.2.3"
+   }
+   ```
 
-- AWS region (e.g., `-var="region=us-west-1"`)
-- AWS profile (e.g., `-var="aws_profile=my-profile"`)
-
-
-# (Optional) Sync state to S3 bucket
-Optionally, you can save terraform state to s3 bucket.
-1. explicitly defined the backend in providers.tf, otherwise you will see terraform raised warning about `-backend-config was used without a "backend" block in the configuration.`
-```hcl
-terraform {
-  backend "s3" {
-    bucket  = <bucket>
-    key     = "terraform.tfstate"
-    region  = <region>
-    encrypt = true
-  }
-}
-```
-2. Migrate the state from local to s3 (note you may need to switch workspace (via tenant) if you are under multitenant environment `terraform workspace select <tenant>`), then
-```bash
-terraform init
-```
-3. Create new workspace
-```bash
-terraform workspace new <tenant>
-4. Plan the change
-```bash
- terraform plan -var="tenant=<tenant>" -var="region=<region>" -var="aws_profile=<profile>"
-```
-5. Apply if things looks sanity
-```bash
- terraform apply -var="tenant=<tenant>" -var="region=<region>" -var="aws_profile=<profile>"
-```
-if you see `Role with name <name> already exists`, import it:
-```bash
-TENANT=<tenant>
-AWS_PROFILE=<profile>
-AWS_REGION=<region>
-
-terraform import -var="tenant=$TENANT" -var="aws_profile=$AWS_PROFILE" -var="region=$AWS_REGION" module.bootstrap.aws_iam_role.deductive_role DeductiveAssumeRole
-
-terraform import -var="tenant=$TENANT" -var="aws_profile=$AWS_PROFILE" -var="region=$AWS_REGION" module.bootstrap.aws_iam_role.eks_cluster_role DeductiveAIEKSClusterRole
-
-terraform import -var="tenant=$TENANT" -var="aws_profile=$AWS_PROFILE" -var="region=$AWS_REGION" module.bootstrap.aws_iam_role.ec2_role  DeductiveAIEC2Role-${TENANT}
-```
-
-# Common FAQ
-If you see terraform version issue, please refer to [terraform](https://developer.hashicorp.com/terraform/install)
-for installing the latest version.
-
-# Development
-If you want to submit the change, don't forget to install `tflint`, `tfsec`, and `checkov`.
+   Share the `deductive_role_arn` value with your Deductive AI representative.

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -47,5 +47,3 @@ role_info = {
 | Name | Description |
 |------|-------------|
 | deductive_role_arn | The ARN of the Deductive role |
-| eks_cluster_role_arn | The ARN of the EKS cluster role |
-| ec2_role_arn | The ARN of the EC2 role |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -5,8 +5,6 @@ This module provides the core infrastructure required for Deductive AI to operat
 ## Resources Created
 
 - **DeductiveAssumeRole**: Main role that Deductive AI will assume to manage resources
-- **EKS Cluster Role**: Role for EKS cluster with permissions to manage EKS services
-- **EC2 Role**: Role for EC2 instances that run as worker nodes in the EKS cluster
 
 ## Usage
 

--- a/modules/bootstrap/data.tf
+++ b/modules/bootstrap/data.tf
@@ -8,6 +8,10 @@
 */
 data "aws_caller_identity" "current" {}
 
+data "external" "git_branch" {
+  program = ["sh", "-c", "echo '{\"branch\": \"'$(git rev-parse --abbrev-ref HEAD)'\"}'"]
+}
+
 ###########################################
 # POLICY DOCUMENTS (IAM Policy Definitions)
 ###########################################

--- a/modules/bootstrap/data.tf
+++ b/modules/bootstrap/data.tf
@@ -8,9 +8,10 @@
 */
 data "aws_caller_identity" "current" {}
 
-data "external" "git_branch" {
-  program = ["sh", "-c", "echo '{\"branch\": \"'$(git rev-parse --abbrev-ref HEAD)'\"}'"]
+data "external" "git_version" {
+  program = ["sh", "-c", "echo '{\"version\": \"'$(git describe --tags --always --dirty)'\"}'"]
 }
+
 
 ###########################################
 # POLICY DOCUMENTS (IAM Policy Definitions)

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -24,7 +24,8 @@ locals {
 
 # Create the main Deductive role
 resource "aws_iam_role" "deductive_role" {
-  name               = "DeductiveAssumeRole"
+  // The name is actually DeductiveAIAssumeRole-<tenant> for example DeductiveAIAssumeRole-deductiveai
+  name               = "${local.resource_prefix}AssumeRole-${var.tenant}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
   tags = merge(
     var.additional_tags,
@@ -52,91 +53,4 @@ resource "aws_iam_role_policy" "secrets_management_policy" {
 resource "aws_iam_role_policy_attachment" "ebs_csi_driver_policy_attachment" {
   role       = aws_iam_role.deductive_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-}
-
-# Create the EKS cluster role
-resource "aws_iam_role" "eks_cluster_role" {
-  name = "${local.resource_prefix}EKSClusterRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "eks.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-
-  tags = merge(
-    var.additional_tags,
-    {
-      creator = "deductive-ai"
-    }
-  )
-}
-
-# Attach the necessary policies to the EKS cluster role
-resource "aws_iam_role_policy_attachment" "eks_cluster_policy_attachments" {
-  for_each = toset([
-    "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
-    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
-    "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
-  ])
-
-  role       = aws_iam_role.eks_cluster_role.name
-  policy_arn = each.value
-}
-
-# Create the EC2 role for worker nodes
-resource "aws_iam_role" "ec2_role" {
-  name = "${local.resource_prefix}EC2Role-${var.tenant}"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "ec2.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-
-  tags = merge(
-    var.additional_tags,
-    {
-      creator = "deductive-ai"
-    }
-  )
-}
-
-# Attach the necessary policies to the EC2 role
-resource "aws_iam_role_policy_attachment" "ec2_policy_attachments" {
-  for_each = toset([
-    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-    "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
-    # For Karpenter to manage spot instances https://karpenter.sh/docs/getting-started/migrating-from-cas/
-    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  ])
-
-  role       = aws_iam_role.ec2_role.name
-  policy_arn = each.value
-}
-
-
-
-# Attach custom policy to ec2 role
-resource "aws_iam_role_policy" "ec2_custom_policy" {
-  name   = "${local.resource_prefix}EC2CustomPolicy"
-  role   = aws_iam_role.ec2_role.id
-  policy = data.aws_iam_policy_document.ec2_custom_policy_document.json
 }

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -14,7 +14,7 @@ output "deductive_role_arn" {
   value       = aws_iam_role.deductive_role.arn
 }
 
-output "git_branch" {
-  description = "The current Git branch name"
-  value       = data.external.git_branch.result.branch
+output "git_version" {
+  description = "The current Git version"
+  value       = data.external.git_version.result.version
 }

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -14,12 +14,7 @@ output "deductive_role_arn" {
   value       = aws_iam_role.deductive_role.arn
 }
 
-output "eks_cluster_role_arn" {
-  description = "The ARN of the EKS cluster role that allows EKS control plane to manage resources"
-  value       = aws_iam_role.eks_cluster_role.arn
+output "git_branch" {
+  description = "The current Git branch name"
+  value       = data.external.git_branch.result.branch
 }
-
-output "ec2_role_arn" {
-  description = "The ARN of the EC2 instance role for worker nodes in the EKS cluster"
-  value       = aws_iam_role.ec2_role.arn
-} 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,6 @@ output "share_with_deductive" {
   value = {
     "aws_region"         = var.region
     "deductive_role_arn" = module.bootstrap.deductive_role_arn
-    "aws_setup_version"  = module.bootstrap.git_branch
+    "release_version"    = module.bootstrap.git_version
   }
 } 

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,8 +2,8 @@
 output "share_with_deductive" {
   description = "The ARNs of the resources to share with Deductive AI"
   value = {
-    "aws_region"           = var.region
-    "deductive_role_arn"   = module.bootstrap.deductive_role_arn
-    "aws_setup_version"       = module.bootstrap.git_branch
+    "aws_region"         = var.region
+    "deductive_role_arn" = module.bootstrap.deductive_role_arn
+    "aws_setup_version"  = module.bootstrap.git_branch
   }
 } 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
+
 output "share_with_deductive" {
   description = "The ARNs of the resources to share with Deductive AI"
   value = {
     "aws_region"           = var.region
     "deductive_role_arn"   = module.bootstrap.deductive_role_arn
-    "eks_cluster_role_arn" = module.bootstrap.eks_cluster_role_arn
-    "ec2_role_arn"         = module.bootstrap.ec2_role_arn
+    "aws_setup_version"       = module.bootstrap.git_branch
   }
 } 

--- a/providers.tf
+++ b/providers.tf
@@ -7,12 +7,12 @@
  the license agreement you entered into with Deductive AI, Inc.
 */
 terraform {
-  # backend "s3" {
-  #   bucket  = "deductive-ai-iac"
-  #   key     = "terraform.tfstate"
-  #   region  = "us-west-1"
-  #   encrypt = true
-  # }
+  backend "s3" {
+    bucket  = "deductive-ai-iac"
+    key     = "terraform.tfstate"
+    region  = "us-west-1"
+    encrypt = true
+  }
 }
 
 provider "aws" {

--- a/providers.tf
+++ b/providers.tf
@@ -7,12 +7,12 @@
  the license agreement you entered into with Deductive AI, Inc.
 */
 terraform {
-  backend "s3" {
-    bucket  = "deductive-ai-iac"
-    key     = "terraform.tfstate"
-    region  = "us-west-1"
-    encrypt = true
-  }
+  # backend "s3" {
+  #   bucket  = "deductive-ai-iac"
+  #   key     = "terraform.tfstate"
+  #   region  = "us-west-1"
+  #   encrypt = true
+  # }
 }
 
 provider "aws" {

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -17,4 +17,4 @@ tfsec . --soft-fail
 checkov -d . --framework terraform --quiet --soft-fail || true
 terraform test
 
-echo "All validation checks passed!" 
+echo "All validation checks passed!"


### PR DESCRIPTION
This is part of the IaC zero touch effort. Needs to work with IaC provision change together. 

Tested=test on provision a new eks (troubleshooter) under seperate account