### PR TITLE
[IaC] Introduce privatelink for loki access

### DIFF
--- a/modules/bootstrap/data.tf
+++ b/modules/bootstrap/data.tf
@@ -47,6 +47,8 @@ data "aws_iam_policy_document" "deductive_policy" {
       "ec2:Describe*",
       "ec2:Get*",
       "ec2:List*",
+      # PrivateLink cross-region connectivity
+      "vpce:AllowMultiRegion",
       # ELB Read-Only Actions
       "elasticloadbalancing:Describe*",
       # EKS Read-Only Actions
@@ -182,6 +184,7 @@ data "aws_iam_policy_document" "deductive_policy" {
       "ec2:CreateInternetGateway",
       "ec2:CreateNatGateway",
       "ec2:CreateVpc",
+      "ec2:CreateVpcEndpoint",
       "ec2:CreateVpcPeeringConnection",
       "ec2:CreateSecurityGroup",
       "ec2:CreateSubnet",
@@ -228,6 +231,7 @@ data "aws_iam_policy_document" "deductive_policy" {
       "ec2:CreateSecurityGroup",
       "ec2:CreateSubnet",
       "ec2:CreateRouteTable",
+      "ec2:CreateVpcEndpoint",
       # Required to terminate, reboot, stop and start instances
       "ec2:TerminateInstances",
       "ec2:RebootInstances",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands IAM permissions in the bootstrap module to allow creating VPC endpoints and enabling multi-region PrivateLink, which affects network connectivity and increases allowed actions in a security-sensitive policy.
> 
> **Overview**
> Updates `modules/bootstrap/data.tf` to broaden the `deductive_policy` IAM permissions for PrivateLink/VPC endpoint support.
> 
> Adds `vpce:AllowMultiRegion` to the read-only statement and grants `ec2:CreateVpcEndpoint` in the EC2/VPC creation and management action sets so the bootstrap role can provision PrivateLink endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e75cf8f0a29031b07f2d813039157b6fe67135a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->