### PR TITLE
Add dns support for privatelink

### DIFF
--- a/modules/bootstrap/data.tf
+++ b/modules/bootstrap/data.tf
@@ -683,6 +683,18 @@ data "aws_iam_policy_document" "deductive_policy" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.resource_prefix}EC2Role*"
     ]
   }
+
+  # Required only when enabling Private DNS on a VPC Endpoint (PrivateLink feature).
+  # Without this permission, ModifyVpcEndpoint will fail with UnauthorizedOperation when
+  # private_dns_enabled = true is set on an aws:ec2:VpcEndpoint resource.
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:AssociateVPCWithHostedZone",
+      "route53:DisassociateVPCFromHostedZone"
+    ]
+    resources = ["*"]
+  }
 }
 
 # Define the secrets management policy document


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands the bootstrap IAM policy with broad Route53 permissions (`resources = ["*"]`), which could affect DNS/VPC associations if misused, but the change is small and targeted to PrivateLink private DNS enablement.
> 
> **Overview**
> Adds Route53 permissions to the bootstrap `deductive_policy` to support enabling *Private DNS* on VPC endpoints (PrivateLink). Specifically allows `route53:AssociateVPCWithHostedZone` and `route53:DisassociateVPCFromHostedZone` so `ModifyVpcEndpoint` succeeds when `private_dns_enabled = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dba95c6807698470b20e5453044a1c1c9b331a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->